### PR TITLE
Add API key saving and auto navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# AutoQuestion
+# AutoQuestion Chrome Extension
+
+This project contains a proof‑of‑concept Chrome extension that uses OCR and an AI API to automatically recognise simple quiz questions on a web page and attempt to fill in answers.
+
+## Features
+
+- Captures the current tab as an image and runs OCR (using `tesseract.js`).
+- Sends the recognised text to an OpenAI API endpoint to receive an answer.
+- Tries to infer the question type (fill in the blank, single choice, multiple choice or boolean).
+- Injects the answer back into the page by selecting appropriate form elements.
+- Automatically clicks "Next"/"下一题" and "Submit"/"提交" buttons when found.
+- Provides a popup UI to save your API key, trigger the process and display logs.
+
+## Usage
+
+1. Open the `extension/` folder in Chrome's Extension settings (`chrome://extensions`), enable developer mode and load it as an unpacked extension.
+2. Click the extension icon and enter your OpenAI API key. Press **Save Key** to store it.
+3. Press **Capture & Solve**. The extension captures the visible tab, runs OCR and asks the AI for an answer.
+4. The detected answer is injected back into the page. The extension will try to click buttons labelled "Next"/"下一题" or "Submit"/"提交" automatically.
+
+This is a minimal example and may need additional logic to reliably locate form fields or navigate multi‑page quizzes.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'capture') {
+    chrome.tabs.captureVisibleTab(null, {format: 'png'}, (dataUrl) => {
+      sendResponse({image: dataUrl});
+    });
+    return true; // async
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,56 @@
+function findInputs() {
+  return Array.from(document.querySelectorAll('input, textarea, select'));
+}
+
+function matchOption(optionText, answer) {
+  return optionText.trim().toLowerCase() === answer.trim().toLowerCase();
+}
+
+function fillAnswer(type, answer) {
+  const inputs = findInputs();
+  if (!inputs.length) return;
+
+  switch (type) {
+    case 'fill':
+      const input = inputs.find(el => el.type === 'text' || el.tagName === 'TEXTAREA');
+      if (input) input.value = answer;
+      break;
+    case 'single':
+    case 'bool':
+      inputs.forEach(el => {
+        if (el.type === 'radio' || el.type === 'checkbox') {
+          const label = document.querySelector(`label[for="${el.id}"]`);
+          const text = label ? label.innerText : el.value;
+          if (matchOption(text, answer)) {
+            el.click();
+          }
+        }
+      });
+      break;
+    case 'multiple':
+      const answers = Array.isArray(answer) ? answer : answer.split(/[,;\s]+/);
+      inputs.forEach(el => {
+        if (el.type === 'checkbox') {
+          const label = document.querySelector(`label[for="${el.id}"]`);
+          const text = label ? label.innerText : el.value;
+          if (answers.some(a => matchOption(text, a))) {
+            if (!el.checked) el.click();
+          }
+        }
+      });
+      break;
+  }
+}
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'fill') {
+    fillAnswer(msg.questionType, msg.answer);
+  } else if (msg.type === 'clickButton') {
+    const buttons = document.querySelectorAll('button, input[type="button"], input[type="submit"]');
+    buttons.forEach(btn => {
+      if (btn.innerText.includes(msg.text) || btn.value?.includes(msg.text)) {
+        btn.click();
+      }
+    });
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "AutoQuestion AI Helper",
+  "description": "Automatically recognize questions with OCR and AI and fill answers.",
+  "version": "0.1",
+  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "AutoQuestion"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { font-family: sans-serif; width: 300px; }
+    textarea { width: 100%; height: 150px; }
+  </style>
+</head>
+<body>
+  <input id="apiKey" type="password" placeholder="OpenAI API key" />
+  <button id="saveKey">Save Key</button>
+  <button id="start">Capture & Solve</button>
+  <pre id="log"></pre>
+  <script src="https://unpkg.com/tesseract.js@5.0.0/dist/tesseract.min.js"></script>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,95 @@
+const log = document.getElementById('log');
+const startBtn = document.getElementById('start');
+const apiKeyInput = document.getElementById('apiKey');
+const saveKeyBtn = document.getElementById('saveKey');
+
+function append(text) {
+  log.textContent += text + '\n';
+}
+
+function loadKey() {
+  const k = localStorage.getItem('openai_key') || '';
+  apiKeyInput.value = k;
+}
+
+function saveKey() {
+  localStorage.setItem('openai_key', apiKeyInput.value.trim());
+  append('API key saved');
+}
+
+async function capture() {
+  const response = await chrome.runtime.sendMessage({type: 'capture'});
+  return response.image;
+}
+
+async function recognize(image) {
+  append('Running OCR...');
+  const worker = Tesseract.createWorker();
+  await worker.load();
+  await worker.loadLanguage('eng');
+  await worker.initialize('eng');
+  const { data: { text } } = await worker.recognize(image);
+  await worker.terminate();
+  append('OCR done');
+  return text;
+}
+
+async function askAI(text) {
+  append('Querying AI...');
+  const apiKey = localStorage.getItem('openai_key');
+  if (!apiKey) {
+    append('No API key set.');
+    return '';
+  }
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You answer quiz questions succinctly.' },
+        { role: 'user', content: text }
+      ]
+    })
+  });
+  const data = await res.json();
+  const answer = data.choices[0].message.content.trim();
+  append('AI answered: ' + answer);
+  return answer;
+}
+
+async function solve() {
+  startBtn.disabled = true;
+  append('Capturing...');
+  const img = await capture();
+  const text = await recognize(img);
+  append(text);
+  const answer = await askAI(text);
+  if (!answer) {
+    startBtn.disabled = false;
+    return;
+  }
+  const type = inferType(text);
+  chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+    chrome.tabs.sendMessage(tabs[0].id, {type: 'fill', questionType: type, answer});
+    chrome.tabs.sendMessage(tabs[0].id, {type: 'clickButton', text: 'Next'});
+    chrome.tabs.sendMessage(tabs[0].id, {type: 'clickButton', text: '下一题'});
+    chrome.tabs.sendMessage(tabs[0].id, {type: 'clickButton', text: 'Submit'});
+    chrome.tabs.sendMessage(tabs[0].id, {type: 'clickButton', text: '提交'});
+  });
+}
+
+function inferType(text) {
+  text = text.toLowerCase();
+  if (text.includes('true') || text.includes('false')) return 'bool';
+  if (text.includes('choose one')) return 'single';
+  if (text.includes('choose all')) return 'multiple';
+  return 'fill';
+}
+
+startBtn.addEventListener('click', solve);
+saveKeyBtn.addEventListener('click', saveKey);
+document.addEventListener('DOMContentLoaded', loadKey);


### PR DESCRIPTION
## Summary
- improve popup UI: add API key input and save button
- store/reload API key from localStorage
- automatically click Next and Submit buttons after filling answer
- update README usage and features

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b1e98dc388322aed3e2909748f5d8