### PR TITLE
Add OCR step for AI analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# AutoQuestion
+# AutoQuestion Chrome Extension
+
+This project contains a proof‑of‑concept Chrome extension that uses the OpenAI API to automatically recognise simple quiz questions on a web page and attempt to fill in answers.
+
+## Features
+
+- Captures the current tab as an image and extracts all interactive elements. A lightweight OCR step attempts to read text from the screenshot.
+- Sends the screenshot and element structure to the OpenAI API which returns a list of DOM actions.
+- Executes the returned actions to fill in answers or click navigation buttons until submission.
+- Provides a popup UI to save your API key, start/stop solving and display logs, recognised questions and AI analysis.
+- Tracks how many questions have been answered during a solving session.
+- Displays how many DOM actions are executed for each question and the running total.
+
+## Usage
+
+1. Open the `extension/` folder in Chrome's Extension settings (`chrome://extensions`), enable developer mode and load it as an unpacked extension.
+2. Click the extension icon and enter your OpenAI API key. Press **Save Key** to store it.
+3. Press **Capture & Solve** to begin answering. Use **Stop** to halt the process at any time.
+4. The extension captures the visible tab, asks the AI for DOM actions and executes them while automatically clicking "Next" or "Submit". The popup shows the recognised question text, analysis, the number of actions taken for the last question and a running total.
+
+This is a minimal example and may need additional logic to reliably locate form fields or navigate multi‑page quizzes.
+
+The OCR feature uses [Tesseract.js](https://github.com/naptha/tesseract.js). The extension dynamically loads the library from a CDN, so network access is required when using this feature.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'capture') {
+    chrome.tabs.captureVisibleTab(null, {format: 'png'}, (dataUrl) => {
+      sendResponse({image: dataUrl});
+    });
+    return true; // async
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,121 @@
+function findInputs() {
+  return Array.from(document.querySelectorAll('input, textarea, select'));
+}
+
+function getUniqueSelector(el) {
+  if (el.id) return `#${el.id}`;
+  const path = [];
+  while (el && el.nodeType === 1 && path.length < 4) {
+    let selector = el.nodeName.toLowerCase();
+    if (el.className) {
+      const classes = el.className.trim().split(/\s+/).slice(0, 2).join('.');
+      if (classes) selector += `.${classes}`;
+    }
+    const sibling = Array.from(el.parentNode.children).filter(e => e.nodeName === el.nodeName);
+    if (sibling.length > 1) selector += `:nth-child(${Array.from(el.parentNode.children).indexOf(el)+1})`;
+    path.unshift(selector);
+    el = el.parentNode;
+  }
+  return path.join('>');
+}
+
+function extractNodes() {
+  const elements = [];
+  document.querySelectorAll('input, button, select, textarea, label').forEach((el, idx) => {
+    const rect = el.getBoundingClientRect();
+    elements.push({
+      tag: el.tagName.toLowerCase(),
+      type: el.type || '',
+      text: el.innerText || el.value || el.placeholder || '',
+      selector: getUniqueSelector(el),
+      rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      index: idx
+    });
+  });
+  return elements;
+}
+
+function executeActions(actions) {
+  actions.forEach(a => {
+    const el = document.querySelector(a.selector);
+    if (!el) return;
+    if (a.action === 'click') {
+      el.click();
+    }
+    if (a.action === 'input') {
+      el.value = a.value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  });
+}
+
+function matchOption(optionText, answer) {
+  return optionText.trim().toLowerCase() === answer.trim().toLowerCase();
+}
+
+function fillAnswer(type, answer) {
+  const inputs = findInputs();
+  if (!inputs.length) return;
+
+  switch (type) {
+    case 'fill':
+      const input = inputs.find(el => el.type === 'text' || el.tagName === 'TEXTAREA');
+      if (input) input.value = answer;
+      break;
+    case 'single':
+    case 'bool':
+      inputs.forEach(el => {
+        if (el.type === 'radio' || el.type === 'checkbox') {
+          const label = document.querySelector(`label[for="${el.id}"]`);
+          const text = label ? label.innerText : el.value;
+          if (matchOption(text, answer)) {
+            el.click();
+          }
+        }
+      });
+      break;
+    case 'multiple':
+      const answers = Array.isArray(answer) ? answer : answer.split(/[,;\s]+/);
+      inputs.forEach(el => {
+        if (el.type === 'checkbox') {
+          const label = document.querySelector(`label[for="${el.id}"]`);
+          const text = label ? label.innerText : el.value;
+          if (answers.some(a => matchOption(text, a))) {
+            if (!el.checked) el.click();
+          }
+        }
+      });
+      break;
+  }
+}
+
+function hasButton(text) {
+  const buttons = document.querySelectorAll('button, input[type="button"], input[type="submit"]');
+  const t = text.trim().toLowerCase();
+  return Array.from(buttons).some(btn => {
+    const bText = (btn.innerText || btn.value || '').trim().toLowerCase();
+    return bText.includes(t);
+  });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'fill') {
+    fillAnswer(msg.questionType, msg.answer);
+  } else if (msg.type === 'clickButton') {
+    const target = (msg.text || '').trim().toLowerCase();
+    const buttons = document.querySelectorAll('button, input[type="button"], input[type="submit"]');
+    buttons.forEach(btn => {
+      const bText = (btn.innerText || btn.value || '').trim().toLowerCase();
+      if (bText.includes(target)) {
+        btn.click();
+      }
+    });
+  } else if (msg.type === 'hasButton') {
+    sendResponse({exists: hasButton(msg.text)});
+  } else if (msg.type === 'extractNodes') {
+    sendResponse({elements: extractNodes()});
+  } else if (msg.type === 'runActions') {
+    executeActions(msg.actions || []);
+  }
+  return true;
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 3,
+  "name": "AutoQuestion AI Helper",
+  "description": "Automatically recognize questions with OCR and AI and fill answers.",
+  "version": "0.1",
+  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "host_permissions": ["https://api.openai.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "AutoQuestion"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' https://cdn.jsdelivr.net; object-src 'self'"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { font-family: sans-serif; width: 300px; }
+    textarea { width: 100%; height: 150px; }
+  </style>
+</head>
+<body>
+  <input id="apiKey" type="password" placeholder="OpenAI API key" />
+  <button id="saveKey">Save Key</button>
+  <button id="start">Capture & Solve</button>
+  <button id="stop" disabled>Stop</button>
+  <div><strong>Answered:</strong> <span id="count">0</span></div>
+  <div><strong>Actions this question:</strong> <span id="lastActions">0</span></div>
+  <div><strong>Total actions:</strong> <span id="totalActions">0</span></div>
+  <div>
+    <strong>Question:</strong>
+    <div id="question"></div>
+  </div>
+  <div>
+    <strong>Analysis:</strong>
+    <div id="analysis"></div>
+  </div>
+  <pre id="log"></pre>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,179 @@
+const log = document.getElementById('log');
+const startBtn = document.getElementById('start');
+const stopBtn = document.getElementById('stop');
+const apiKeyInput = document.getElementById('apiKey');
+const saveKeyBtn = document.getElementById('saveKey');
+const questionEl = document.getElementById('question');
+const analysisEl = document.getElementById('analysis');
+const countEl = document.getElementById('count');
+const lastActionsEl = document.getElementById('lastActions');
+const totalActionsEl = document.getElementById('totalActions');
+let running = false;
+let count = 0;
+let totalActions = 0;
+
+async function ocrImage(image) {
+  try {
+    if (typeof Tesseract === 'undefined') {
+      await import('https://cdn.jsdelivr.net/npm/tesseract.js@5.0.3/dist/tesseract.esm.min.js');
+    }
+    const { data: { text } } = await Tesseract.recognize(image, 'eng');
+    append('OCR: ' + text.trim().slice(0, 80));
+    return text;
+  } catch (e) {
+    append('OCR failed: ' + e.message);
+    return '';
+  }
+}
+
+function append(text) {
+  log.textContent += text + '\n';
+}
+
+function loadKey() {
+  const k = localStorage.getItem('openai_key') || '';
+  apiKeyInput.value = k;
+}
+
+function saveKey() {
+  localStorage.setItem('openai_key', apiKeyInput.value.trim());
+  append('API key saved');
+}
+
+async function capture() {
+  const response = await chrome.runtime.sendMessage({type: 'capture'});
+  return response.image;
+}
+
+async function extractElements(tabId) {
+  const res = await send(tabId, {type: 'extractNodes'});
+  return res?.elements || [];
+}
+
+async function askAI(image, elements, ocrText) {
+  append('Querying AI...');
+  const apiKey = localStorage.getItem('openai_key');
+  if (!apiKey) {
+    append('No API key set.');
+    return null;
+  }
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a web quiz solving bot. Using the following OCR text, screenshot and list of form elements, identify the question and compute the answer. Respond only with JSON {"question":"","analysis":"","actions":[]} where actions use CSS selectors.'
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: ocrText || '' },
+            { type: 'image_url', image_url: { url: image } },
+            { type: 'text', text: JSON.stringify(elements) }
+          ]
+        }
+      ],
+      max_tokens: 400
+    })
+  });
+  const data = await res.json();
+  const answer = data.choices?.[0]?.message?.content || '';
+  append('AI answered: ' + answer);
+  let jsonText = '';
+  const match = answer.match(/\{[\s\S]*\}/);
+  if (match) jsonText = match[0];
+  try {
+    const parsed = JSON.parse(jsonText || answer);
+    if (parsed.question) {
+      append('Q: ' + parsed.question);
+      questionEl.textContent = parsed.question;
+    }
+    if (parsed.analysis) {
+      append('Analysis: ' + parsed.analysis);
+      analysisEl.textContent = parsed.analysis;
+    }
+    return parsed.actions;
+  } catch(e) {
+    append('Failed to parse actions');
+    return null;
+  }
+}
+
+function send(tabId, msg) {
+  return new Promise(res => chrome.tabs.sendMessage(tabId, msg, res));
+}
+
+async function solveCurrent(tabId) {
+  append('Capturing...');
+  const img = await capture();
+  const elements = await extractElements(tabId);
+  const ocrText = await ocrImage(img);
+  const actions = await askAI(img, elements, ocrText);
+  if (!actions) return false;
+  await send(tabId, {type: 'runActions', actions});
+  append('Executed ' + actions.length + ' actions');
+  lastActionsEl.textContent = String(actions.length);
+  totalActions += actions.length;
+  totalActionsEl.textContent = String(totalActions);
+
+  const hasNext = await send(tabId, {type: 'hasButton', text: 'Next'});
+  const hasCnNext = await send(tabId, {type: 'hasButton', text: '下一题'});
+  const hasSubmit = await send(tabId, {type: 'hasButton', text: 'Submit'});
+  const hasCnSubmit = await send(tabId, {type: 'hasButton', text: '提交'});
+
+  if (hasNext?.exists || hasCnNext?.exists) {
+    await send(tabId, {type: 'clickButton', text: 'Next'});
+    await send(tabId, {type: 'clickButton', text: '下一题'});
+    return true;
+  } else if (hasSubmit?.exists || hasCnSubmit?.exists) {
+    await send(tabId, {type: 'clickButton', text: 'Submit'});
+    await send(tabId, {type: 'clickButton', text: '提交'});
+    return false;
+  }
+  append('No navigation button found');
+  return false;
+}
+
+async function solve() {
+  running = true;
+  startBtn.disabled = true;
+  stopBtn.disabled = false;
+  questionEl.textContent = '';
+  analysisEl.textContent = '';
+  log.textContent = '';
+  count = 0;
+  countEl.textContent = '0';
+  totalActions = 0;
+  totalActionsEl.textContent = '0';
+  lastActionsEl.textContent = '0';
+  const [tab] = await chrome.tabs.query({active: true, currentWindow: true});
+  while (running) {
+    const cont = await solveCurrent(tab.id);
+    if (cont) {
+      count += 1;
+      countEl.textContent = String(count);
+    }
+    if (!cont) break;
+    await new Promise(r => setTimeout(r, 2000));
+  }
+  running = false;
+  startBtn.disabled = false;
+  stopBtn.disabled = true;
+}
+
+startBtn.addEventListener('click', solve);
+stopBtn.addEventListener('click', () => {
+  running = false;
+  stopBtn.disabled = true;
+  startBtn.disabled = false;
+  append('Stopped');
+  lastActionsEl.textContent = '0';
+});
+saveKeyBtn.addEventListener('click', saveKey);
+document.addEventListener('DOMContentLoaded', loadKey);


### PR DESCRIPTION
## Summary
- integrate optional OCR via Tesseract.js and show short results in the popup log
- pass OCR text to the OpenAI request so the model can better analyse questions
- allow loading Tesseract from CDN with an extension content security policy
- document the OCR requirement in the README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b1e98dc388322aed3e2909748f5d8